### PR TITLE
Fix #6 Update generate key example

### DIFF
--- a/php-microform/generatekey.php
+++ b/php-microform/generatekey.php
@@ -8,17 +8,17 @@
 	$merchantConfig = $commonElement->merchantConfigObject();
 	$apiclient = new CyberSource\ApiClient($config, $merchantConfig);
 	$api_instance = new CyberSource\Api\KeyGenerationApi($apiclient);
-	$flexRequestArr = [
-	"encryptionType" => "RsaOaep256",
-	"targetOrigin" => "http://localhost:8000",
-	];
+	$flexRequest = new GeneratePublicKeyRequest([
+		"encryptionType" => "RsaOaep256",
+		"targetOrigin" => "http://localhost:8000",
+	]);	
 	
 	$keyResponse = list($response, $statusCode, $httpHeader)=null;
 	$captureContext = '';
 
 	try {
 		// Generating Flex .11 capture context 
-		$keyResponse = $api_instance->generatePublicKey($format = 'JWT', $flexRequestArr);
+		$keyResponse = $api_instance->generatePublicKey($format = 'JWT', $flexRequest);
 		//print_r($keyResponse);
 
 		//Extracting Capture context from KeyID in response


### PR DESCRIPTION
Sending a native array causes masking (and probably other things) to fail w/the new SDK